### PR TITLE
[PD] Add allowed host env var

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,5 +11,8 @@ module.exports = merge(common, {
     port: 3000,
     open: true,
     hot: true,
+    ...(process.env.ALLOWED_HOST && {
+      allowedHosts: [process.env.ALLOWED_HOST],
+    }),
   },
 });


### PR DESCRIPTION
Cuurently the webpage is returning [Invalid Host header](https://anchor-ref-ui-dev.stellar.org/), which is a typical error occurs when request fails the web framework `Host` header check. Adding env var `ALLOWED_HOST` to pass ingress host

Default to `localhost` and machine's ip is not set