### PR TITLE
Add registry alias to public ECR push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,8 @@ jobs:
         id: prd
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
-          ECR_PUBLIC_REGISTRY: ${{ steps.ecr-login.outputs.ecr-public-registry }}
+          ECR_PUBLIC_REGISTRY:
+            ${{ steps.ecr-login.outputs.ecr-public-registry }}
           LABEL: ${{ steps.vars.outputs.label }}
         run: |
           set -eu
@@ -113,8 +114,8 @@ jobs:
           ecr-push "${PRD_TAG}"
 
           # Public ECR Gallery — sha + latest
-          PUBLIC_TAG="${ECR_PUBLIC_REGISTRY}/sep24-reference-ui:${LABEL}"
-          PUBLIC_LATEST="${ECR_PUBLIC_REGISTRY}/sep24-reference-ui:latest"
+          PUBLIC_TAG="${ECR_PUBLIC_REGISTRY}/stellar/sep24-reference-ui:${LABEL}"
+          PUBLIC_LATEST="${ECR_PUBLIC_REGISTRY}/stellar/sep24-reference-ui:latest"
           docker tag "${IMAGE}:${LABEL}" "${PUBLIC_TAG}"
           docker tag "${IMAGE}:${LABEL}" "${PUBLIC_LATEST}"
           docker push "${PUBLIC_TAG}"


### PR DESCRIPTION
The public ECR push in `build.yml` fails with 404 page not found ([run](https://github.com/stellar/sep24-reference-ui/actions/runs/29599448733)) because it's missing the registry alias.

This fixes the push target from `public.ecr.aws/sep24-reference-ui` to `public.ecr.aws/stellar/sep24-reference-ui`. This bug was previously masked because the docker build itself failed before reaching the push step (fixed in #20).

Test run completed: https://github.com/stellar/sep24-reference-ui/actions/runs/29601325446/job/87953874433