### PR TITLE
Add PR preview workflow (GitHub Actions + ArgoCD)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,67 @@
+# PR preview environments, replacing the Jenkins preview pipeline
+# (Jenkinsfile-preview). CI only builds the image and signals with the
+# `preview` label; ArgoCD's preview-sep24-reference-ui ApplicationSet
+# (stellar/kube) does the deploying.
+# See https://github.com/stellar/actions/tree/main/sdf-pr-preview
+
+name: pr-preview
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+# pull_request_target runs in base-repo context, so these are real write
+# permissions even for fork PRs. On `pull_request`, fork runs get no OIDC
+# token and a read-only token.
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  ECR_REPOSITORY: dev/sep24-reference-ui
+  PREVIEW_HOST: sep24-reference-ui-pr-${{ github.event.pull_request.number }}.previews.kube001.services.stellar-ops.com
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      # Nothing that touches PR code may run before the gate, and every step
+      # after it must be guarded by `member == 'true'`.
+      - id: gate
+        uses: stellar/actions/sdf-pr-preview/gate@main
+        with:
+          app-id: ${{ vars.PREVIEW_BOT_APP_ID }}
+          private-key: ${{ secrets.PREVIEW_BOT_PRIVATE_KEY }}
+
+      # PR head SHA, not the default base ref - must match the
+      # ApplicationSet's {{ .head_sha }}.
+      - uses: actions/checkout@v6
+        if: steps.gate.outputs.member == 'true'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - id: ecr-login
+        if: steps.gate.outputs.member == 'true'
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push preview image
+        if: steps.gate.outputs.member == 'true'
+        env:
+          TAG: ${{ steps.ecr-login.outputs.ecr-registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.gate.outputs.image-tag }}
+        run: |
+          set -eu
+          make docker-build
+          make docker-push
+          echo "IMAGE=${TAG}" >> "$GITHUB_ENV"
+
+      - uses: stellar/actions/sdf-pr-preview/publish@main
+        if: steps.gate.outputs.member == 'true'
+        with:
+          images: ${{ env.IMAGE }}
+          preview-host: ${{ env.PREVIEW_HOST }}


### PR DESCRIPTION
Migrates this repo's per-PR preview environments from the Jenkins preview pipeline (stellar/pipelines) to GitHub Actions + ArgoCD.

## How it works
- On every PR event (opened / synchronize / reopened / closed) the workflow runs the [sdf-pr-preview](https://github.com/stellar/actions/tree/main/sdf-pr-preview) composite actions: **gate** (withdraws the `preview` label, checks org membership) -> **build & push** the preview image(s) to dev ECR -> **publish** (verifies the images exist, restores the label, comments the preview URL).
- ArgoCD ApplicationSet(s) `preview-sep24-reference-ui` in stellar/kube watch PRs carrying the `preview` label and deploy one `charts/pr-previews` release per PR. Closing the PR tears the preview down.
- Images are tagged `pr-<number>-<head-sha>`: `dev/sep24-reference-ui`

## Preview URL(s)
- `https://sep24-reference-ui-pr-<number>.previews.kube001.services.stellar-ops.com`

## Security
The workflow runs on `pull_request_target` (required for fork PRs to get OIDC + label/comment permissions). Per the sdf-pr-preview caller contract: the gate runs before any PR code is checked out, and every later step is guarded by `steps.gate.outputs.member == 'true'`, so non-member PRs never build.

## Before merging
- [ ] `preview` label exists in this repo
- [ ] `PREVIEW_BOT_APP_ID` repo variable and `PREVIEW_BOT_PRIVATE_KEY` secret are set
- [ ] This repo can assume the dev ECR push role via OIDC (sdf-ecr-login)
- [ ] The matching ApplicationSet + values in stellar/kube are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
